### PR TITLE
fix ansible depreciation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: install hddtemp packages
-  include: packages.yml
+  include_tasks: packages.yml
 
 - name: configure hddtemp
-  include: configure.yml
+  include_tasks: configure.yml


### PR DESCRIPTION
Ansible throws the following depreciation warning for this role:

[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks instead. This feature will be removed in version 2.16. Deprecation warnings can 
be disabled by setting deprecation_warnings=False in ansible.cfg.

PR updates `include:` statements with `include_tasks:`